### PR TITLE
Allow user to provide parameters through HTTP request

### DIFF
--- a/agent/trip/process_trajectory.py
+++ b/agent/trip/process_trajectory.py
@@ -8,6 +8,7 @@ from agent.trip.trip_detection import detect_trips, CH_TRIP_INDEX
 from py4j.java_gateway import JavaObject
 from agent.trip.kg_client import KgClient
 from agent.utils.baselib_gateway import baselib_view, jpsBaseLibGW
+import json
 
 logger = agentlogging.get_logger('dev')
 
@@ -22,6 +23,21 @@ def api():
     iri = request.args['iri']
     upperbound = request.args.get('upperbound')
     lowerbound = request.args.get('lowerbound')
+    
+    # parameter should be provided as a JSOn string
+    params_json_str = request.args.get('params')
+    params = {}
+    
+    if params_json_str:
+        logger.info(f"Received custom parameters: {params_json_str}")
+        try:
+            # Parse the JSON string from the query parameter into a Python dictionary
+            params = json.loads(params_json_str)
+        except json.JSONDecodeError as e:
+            logger.error(f"Failed to decode params: {e}")
+            # Return an HTTP 400 Bad Request error if the JSON is invalid
+            return {"error": f"Invalid JSON in 'params' query parameter: {e}"}, 400
+
 
     time_series_client = TimeSeriesClient(iri)
     kg_client = KgClient()
@@ -62,6 +78,7 @@ def api():
             dataframe,
             iri,
             columns,
+            input_params=params,
             interpolate_helper_func=None,
             code=utm_code
         )

--- a/agent/trip/trip_detection.py
+++ b/agent/trip/trip_detection.py
@@ -1135,7 +1135,7 @@ def make_index(iter, time_series: pd.Series, binary: bool) -> list:
     return index_list
 
 
-def detect_trips(gps_data, pid, columns, params=DEFAULT_PARAMS,
+def detect_trips(gps_data, pid, columns, input_params=None,
                  interpolate_helper_func=interpolate_over_period, code=None):
     """
     Method for detecting trips from GPS data.
@@ -1143,7 +1143,7 @@ def detect_trips(gps_data, pid, columns, params=DEFAULT_PARAMS,
     :param gps_data: data frame containing the GPS data to detect trips on.
     :param pid: a string containing the participant's INTERACT ID (or other unique identifier);
                 Used when generating temporary files.
-    :param params: dictionary containing the parameters for the trip detection, each as described in the documentation.
+    :param input_params: dictionary containing the parameters for the trip detection, each as described in the documentation.
     :param interpolate_helper_func: function to be used to interpolate GPS track. Function signature as follow:
                 interpolate_helper_func(df, columns, frequency, noise). No interpolation if None
     :param columns: a dictionary containing the names of utc_date, lat, lon, utm_n and utm_e columns in the dataframe.
@@ -1156,6 +1156,11 @@ def detect_trips(gps_data, pid, columns, params=DEFAULT_PARAMS,
 
     # Make temporary scratch folder to store intermediate values and prevent thrashing.
     os.makedirs(os.getcwd() + "/temp", exist_ok=True)
+    
+    params = DEFAULT_PARAMS.copy()
+    
+    if input_params:
+        params.update(input_params)
 
     # Load parameters and initialize needed values
     cell_size = params["CELL_SIZE"]  # meters

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   trip-agent:
-    image: ghcr.io/theworldavatar/trip-agent:1.1.0
+    image: ghcr.io/theworldavatar/trip-agent:1.2.0-SNAPSHOT
     build:
       context: .
       target: production


### PR DESCRIPTION
Currently the trip detection parameters are set as defaults.

This branch modified the agent to allow for optional parameter specification. If a parameter is specified by the user, it will be used, otherwise the default is used.

Parameter is provided as a JSON string as part of the URL (needs to be encoded).